### PR TITLE
Fixing umask, which may make the tests fail

### DIFF
--- a/src/opamRTmain.ml
+++ b/src/opamRTmain.ml
@@ -196,5 +196,9 @@ let commands = [
   test;
 ]
 
+let _ =
+  (* Installing files respects umask, which may then create a diff *)
+  Unix.umask 0o022
+
 let () =
   OpamArg.run default commands


### PR DESCRIPTION
Travis was failing because it has 0o002 instead of 0o022, and we install in 0o644/0o755, so the perms on the installed file got different from the original
